### PR TITLE
fix to search updating since_id

### DIFF
--- a/lib/chatterbot/search.rb
+++ b/lib/chatterbot/search.rb
@@ -28,7 +28,7 @@ module Chatterbot
                                       exclude_retweets(query),
                                       opts.merge(default_opts)
                                       )
-        update_since_id(result.max_id)
+        update_since_id(result)
 
         result.collection.each { |s|
           debug s.text


### PR DESCRIPTION
I think that search needs to pass a search result through to Config::update_since_id
rather than the integer tweet id.
