### PR TITLE
Use Twitter version 4.4 as 5.0 is not compatible with the current code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development do
 
   gem "shoulda", ">= 0"
   gem "rspec"
+  gem "twitter", "~> 4.4.0"
 
   gem "watchr"
 end


### PR DESCRIPTION
Twitter gem was updated to 5.0 recently and it caused part of the code to break. 

Until the necessary changes are done, twitter 4.4 should be used
