### PR TITLE
Add db_uri explanation to the readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -217,7 +217,7 @@ your bot:
    it with your bots if desired.
 6. In a database.  You can store your configuration in a DB, and then
    specify the connection string either in one of the global config
-   files, or on the command-line by using the `--db="db_uri"`
+   files by setting `:db_uri: postgres://username:password@host/database`, or on the command-line by using the `--db="db_uri"`
    configuration option.  Any calls to the database are handled by the
    Sequel gem, and MySQL and Sqlite should work.  The DB URI should
    be in the form of `mysql://username:password@host/database` -- see


### PR DESCRIPTION
I went round the houses because I thought that the command line option 'db' would be the right key to use in the config yaml. In fact it is db_uri from reading the code. Otherwise fails with Sequel::Database.connect takes either a Hash or a String, given: nil (Sequel::Error)
