### PR TITLE
fix default options merging into user options

### DIFF
--- a/lib/chatterbot/search.rb
+++ b/lib/chatterbot/search.rb
@@ -24,10 +24,10 @@ module Chatterbot
       # search twitter
       #
       queries.each { |query|
-        debug "search: #{query} #{opts.merge(default_opts)}"
+        debug "search: #{query} #{default_opts.merge(opts)}"
         result = client.search(
                                       exclude_retweets(query),
-                                      opts.merge(default_opts)
+                                      default_opts.merge(opts)
                                       )
         update_since_id(result)
 


### PR DESCRIPTION
Hi!

Currently search options are overwritten by the default_opts hash. The expected behavior is to allow default options to be overwritten by the user options.

Thanks!
