### PR TITLE
Allow auth configuration to be set from environment variables

### DIFF
--- a/lib/chatterbot/config.rb
+++ b/lib/chatterbot/config.rb
@@ -260,7 +260,12 @@ module Chatterbot
     #
     # bot-specific config settings
     def bot_config
-      slurp_file(config_file) || { }
+      {
+        :consumer_key => ENV["chatterbot_consumer_key"],
+        :consumer_secret => ENV["chatterbot_consumer_secret"],
+        :token => ENV["chatterbot_token"],
+        :secret => ENV["chatterbot_secret"]
+      }.merge(slurp_file(config_file) || {})
     end
 
     #


### PR DESCRIPTION
This is quite handy when you want to deploy your bot to Heroku and you don t want to push your secret tokens.
