### PR TITLE
Fixes #26 - Twitter no longer allows since_id of 0

### DIFF
--- a/lib/chatterbot/config.rb
+++ b/lib/chatterbot/config.rb
@@ -95,7 +95,7 @@ module Chatterbot
     #
     # return the ID of the most recent tweet pulled up in searches
     def since_id
-      config[:since_id] || 0
+      config[:since_id] || 1
     end
 
     #


### PR DESCRIPTION
See: https://twittercommunity.com/t/api-v1-1-statuses-user-timeline-since-id-parameter-is-invalid/10202

Seems to fix the issue I'm getting in #26 but I haven't given it extensive testing