### PR TITLE
Update twitter dependency to 5.14.0

### DIFF
--- a/chatterbot.gemspec
+++ b/chatterbot.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency(%q<redcarpet>, [">= 0"])
   s.add_runtime_dependency(%q<oauth>, [">= 0.4.7"])
-  s.add_runtime_dependency(%q<twitter>, ["5.8.0"])
+  s.add_runtime_dependency(%q<twitter>, ["5.14.0"])
   s.add_runtime_dependency(%q<launchy>, [">= 2.4.2"])
   s.add_runtime_dependency(%q<colorize>, [">= 0.7.3"])
   s.add_development_dependency(%q<yard>, [">= 0"])

--- a/lib/chatterbot/blocklist.rb
+++ b/lib/chatterbot/blocklist.rb
@@ -6,13 +6,13 @@ module Chatterbot
     attr_accessor :exclude, :blocklist
 
     alias :blacklist :blocklist
-    
+
     # return a list of text strings which we will check for in incoming tweets.
     # If the text is listed, we won't use this tweet
     def exclude
       @exclude || []
     end
-    
+
     # A list of Twitter users that don't want to hear from the bot.
     def blocklist
       @blocklist || []
@@ -20,7 +20,7 @@ module Chatterbot
     def blocklist=(b)
       @blocklist = b
     end
-    
+
     #
     # Based on the text of this tweet, should it be skipped?
     def skip_me?(s)
@@ -42,13 +42,13 @@ module Chatterbot
 
       !skippable_retweet?(object) && ! on_blocklist?(object) && ! skip_me?(object) && interact_with_user?(object)
     end
-    
+
     #
     # Is this tweet from a user on our blocklist?
     def on_blocklist?(s)
       search = if s.is_a?(Twitter::User)
                  s.name
-               elsif s.respond_to?(:user)
+               elsif s.respond_to?(:user) && !s.is_a?(Twitter::NullObject)
                  from_user(s)
                else
                  s
@@ -56,6 +56,6 @@ module Chatterbot
 
       blocklist.any? { |b| search.include?(b.downcase) }
     end
-    
+
   end
 end

--- a/spec/direct_messages_spec.rb
+++ b/spec/direct_messages_spec.rb
@@ -15,7 +15,7 @@ describe "Chatterbot::DirectMessages" do
         allow(bot).to receive(:client).and_return(double(Twitter::Client))
         allow(bot).to receive(:debug_mode?).and_return(false)
       end
-    
+
       it "calls create_direct_message" do
         test_str = "test!"
         test_user = fake_user("DM Enthusiast")
@@ -55,7 +55,7 @@ describe "Chatterbot::DirectMessages" do
       results = fake_direct_messages(1, 1000)
 
       allow(bot).to receive(:client).and_return(results)
-      
+
       bot.direct_messages do
       end
 
@@ -69,12 +69,12 @@ describe "Chatterbot::DirectMessages" do
       end
 
       it "iterates results" do
-        
+
         expect(bot).to receive(:update_since_id_dm).exactly(3).times
 
         indexes = []
         bot.direct_messages do |x|
-          indexes << x[:id]
+          indexes << x.id
         end
 
         expect(indexes).to eq([1,2,3])
@@ -84,7 +84,7 @@ describe "Chatterbot::DirectMessages" do
         allow(bot).to receive(:on_blocklist?).and_return(true, false, false)
         indexes = []
         bot.direct_messages do |x|
-          indexes << x[:id]
+          indexes << x.id
         end
 
         expect(indexes).to eq([2,3])
@@ -96,7 +96,7 @@ describe "Chatterbot::DirectMessages" do
 
         indexes = []
         bot.direct_messages do |x|
-          indexes << x[:id]
+          indexes << x.id
         end
 
         expect(indexes).to eq([2])
@@ -105,7 +105,7 @@ describe "Chatterbot::DirectMessages" do
 
       it "passes along since_id_dm" do
         allow(bot).to receive(:since_id_dm).and_return(123)
-        
+
         expect(bot.client).to receive(:direct_messages_received).with({:since_id => 123, :count => 200})
 
         bot.direct_messages

--- a/spec/home_timeline_spec.rb
+++ b/spec/home_timeline_spec.rb
@@ -13,7 +13,7 @@ describe "Chatterbot::HomeTimeline" do
     results = fake_home_timeline(1, 1000)
 
     allow(@bot).to receive(:client).and_return(results)
-    
+
     @bot.home_timeline do
     end
 
@@ -26,24 +26,24 @@ describe "Chatterbot::HomeTimeline" do
       expect(@bot).to receive(:require_login).and_return(true)
       allow(@bot).to receive(:client).and_return(fake_home_timeline(3))
     end
-    
+
     it "iterates results" do
       expect(@bot).to receive(:update_since_id_home_timeline).exactly(3).times
-      
+
       indexes = []
       @bot.home_timeline do |x|
-        indexes << x[:id]
+        indexes << x.id
       end
-      
+
       expect(indexes).to eq([1,2,3])
     end
-    
+
     it "checks blocklist" do
       allow(@bot).to receive(:on_blocklist?).and_return(true, false, false)
-           
+
       indexes = []
       @bot.home_timeline do |x|
-        indexes << x[:id]
+        indexes << x.id
       end
 
       expect(indexes).to eq([2,3])
@@ -52,10 +52,10 @@ describe "Chatterbot::HomeTimeline" do
     it "checks safelist" do
       allow(@bot).to receive(:has_safelist?).and_return(true)
       allow(@bot).to receive(:on_safelist?).and_return(true, false, false)
-      
+
       indexes = []
       @bot.home_timeline do |x|
-        indexes << x[:id]
+        indexes << x.id
       end
 
       expect(indexes).to eq([1])

--- a/spec/reply_spec.rb
+++ b/spec/reply_spec.rb
@@ -13,7 +13,7 @@ describe "Chatterbot::Reply" do
     results = fake_replies(1, 1000)
 
     allow(bot).to receive(:client).and_return(results)
-    
+
     bot.replies do
     end
 
@@ -24,12 +24,12 @@ describe "Chatterbot::Reply" do
     bot = test_bot
     expect(bot).to receive(:require_login).and_return(true)
     allow(bot).to receive(:client).and_return(fake_replies(3))
-    
+
     expect(bot).to receive(:update_since_id_reply).exactly(3).times
 
     indexes = []
     bot.replies do |x|
-      indexes << x[:id]
+      indexes << x.id
     end
 
     expect(indexes).to eq([1,2,3])
@@ -39,13 +39,13 @@ describe "Chatterbot::Reply" do
     bot = test_bot
     expect(bot).to receive(:require_login).and_return(true)
     allow(bot).to receive(:client).and_return(fake_replies(3))
-    
+
     allow(bot).to receive(:on_blocklist?).and_return(true, false, false)
 
 
     indexes = []
     bot.replies do |x|
-      indexes << x[:id]
+      indexes << x.id
     end
 
     expect(indexes).to eq([2,3])
@@ -55,9 +55,9 @@ describe "Chatterbot::Reply" do
   it "passes along since_id_reply" do
     bot = test_bot
     expect(bot).to receive(:require_login).and_return(true)
-    allow(bot).to receive(:client).and_return(fake_replies(100, 3))    
+    allow(bot).to receive(:client).and_return(fake_replies(100, 3))
     allow(bot).to receive(:since_id_reply).and_return(123)
-    
+
     expect(bot.client).to receive(:mentions_timeline).with({:since_id => 123, :count => 200})
 
     bot.replies


### PR DESCRIPTION
This is a security fix. chatterbot requires on twitter-5.8.0, which requires http 5.1.0, which is vulnerable to CVE-2015-1828.

Relevant twitter issue: https://github.com/sferik/twitter/issues/672
Vuln info: https://groups.google.com/forum/#!topic/ruby-security-ann/OLZxzGAFBig

Reason for the change in blocklist.rb is because Twitter::NullObject responds true to any method as of 5.14.0:
https://github.com/sferik/twitter/commit/cd32e310610edb5d3e88d1e13fd8d5de8876e2b1#diff-bb8c95cbf19e6d723329bd49aa104600

