### PR TITLE
Clarify reply method example must include username

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -44,6 +44,7 @@ replies do |tweet|
   # replace the incoming username with #USER#, which will be replaced
   # with the handle of the user who tweeted us by the
   # replace_variables helper
+  # Note: reply tweets must begin with an @-mention of the original tweet's username otherwise the text will get tweeted from the bot account as a tweet, not a reply.
   src = tweet.text.gsub(/@echoes_bot/, "#USER#")  
 
   # send it back!


### PR DESCRIPTION
Hey there! 

First, thank you for this incredible gem.

One thing that I was stuck on for some time is that when I wanted my bot to directly reply to a tweet it was just sending a new tweet. After looking at the [twitter gem docs ](https://www.rubydoc.info/gems/twitter/Twitter%2FREST%2FTweets:update) I saw that:
```
:in_reply_to_status (Twitter::Tweet) — An existing status that the update is in reply to. If the status being replied to was not originally posted by the authenticated user, the text of the status must begin with an @-mention, or twitter will reject the update.
```

After I changed the text text I was trying to reply with to begin with an `@-mention` of the original user's name, the `reply` method worked exactly as expected.

This pr adds one line of clarification to the gem examples documentation to try to clarify that reply tweets must start with an at mention.