### PR TITLE
update token names on authorization doc page

### DIFF
--- a/docs/_site/advanced.html
+++ b/docs/_site/advanced.html
@@ -346,10 +346,10 @@ have access to an instance of Twitter::Client provided by the
 <strong>client</strong> method. In theory, you can do something like this in your
 bot to unfollow users who DM you:</p>
 
-<pre><code>client.direct_messages_received(:since_id =&gt; since_id).each do |m|
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>client.direct_messages_received(:since_id =&gt; since_id).each do |m|
     client.unfollow(m.user.name)
 end
-</code></pre>
+</code></pre></div></div>
 
 <h2 id="storing-config-in-the-database">Storing Config in the Database</h2>
 <p>Sometimes it is preferable to store the authorization credentials for
@@ -360,17 +360,16 @@ but to do this you will need to specify how to connect to the
 database. You can do this by specifying the connection string
 either in one of the global config files by setting</p>
 
-<p><code>
-:db_uri:mysql://username:password@host/database
-</code></p>
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>:db_uri:mysql://username:password@host/database
+</code></pre></div></div>
 
 <p>Or you can specify the connection on the command-line by using the
 –db=”db_uri” configuration option. Any calls to the database are
 handled by the Sequel gem, and MySQL and Sqlite should work. The DB
 URI should be in the form of</p>
 
-<pre><code>mysql://username:password@host/database
-</code></pre>
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>mysql://username:password@host/database
+</code></pre></div></div>
 
 <p>see http://sequel.rubyforge.org/rdoc/files/doc/opening_databases_rdoc.html
 for details.</p>
@@ -382,20 +381,15 @@ be handy for archival purposes, or for tracking what’s going on with
 your bot.</p>
 
 <p>If you’ve configured your bot for database access, you can store a
-tweet to the database by calling the <code>log</code> method like this:</p>
+tweet to the database by calling the <code class="language-plaintext highlighter-rouge">log</code> method like this:</p>
 
-<p><code>
-search "chatterbot" do |tweet|
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>search "chatterbot" do |tweet|
     log tweet
 end
-</code></p>
+</code></pre></div></div>
 
-<p>See <code>Chatterbot::Logging</code> for details on this.</p>
+<p>See <code class="language-plaintext highlighter-rouge">Chatterbot::Logging</code> for details on this.</p>
 
-<h2 id="streaming">Streaming</h2>
-
-<p>Chatterbot has basic support for Twitter’s Streaming API. You can read
-more about it <a href="streaming.html">here</a></p>
 
 
                     </div>

--- a/docs/_site/configuration.html
+++ b/docs/_site/configuration.html
@@ -345,7 +345,7 @@ bunch of different methods of storing the config for your bot:</p>
 
 <ol>
   <li>Your credentials can be stored as variables in the script itself.
-If you generate a bot via <code>chatterbot-register</code>, the file will have
+If you generate a bot via <code class="language-plaintext highlighter-rouge">chatterbot-register</code>, the file will have
 these variables specified. However, if your bot source code is
 going to be public, you should NOT do this. Anyone who has your
 credentials can do nasty things with your Twitter account. Also, if
@@ -354,14 +354,14 @@ track some state information, and that data will be written to a
 YAML file.</li>
   <li>In a YAML file with the same name as the bot, so if you have
 botname.rb or a Botname class, store your config in botname.yaml.
-<code>chatterbot-register</code> will also create this file. If you are using
+<code class="language-plaintext highlighter-rouge">chatterbot-register</code> will also create this file. If you are using
 git or another source code control system, you should <strong>NOT</strong> store
 this file! It will be updated every time your bots run.</li>
-  <li>In a global config file at <code>/etc/chatterbot.yml</code> – values stored here
+  <li>In a global config file at <code class="language-plaintext highlighter-rouge">/etc/chatterbot.yml</code> – values stored here
 will apply to any bots you run.</li>
   <li>In another global config file specified in the environment variable
-<code>'chatterbot_config'</code>.</li>
-  <li>In a <code>global.yml</code> file in the same directory as your bot.  This
+<code class="language-plaintext highlighter-rouge">'chatterbot_config'</code>.</li>
+  <li>In a <code class="language-plaintext highlighter-rouge">global.yml</code> file in the same directory as your bot.  This
 gives you the ability to have a global configuration file, but keep
 it with your bots if desired.</li>
   <li>In a database.  You can read more about this on the <a href="advanced.html">Advanced

--- a/docs/_site/deploying.html
+++ b/docs/_site/deploying.html
@@ -348,40 +348,34 @@
 <h2 id="cron">Cron</h2>
 <p>Run it via cron.  Here’s an example of running a bot every two minutes</p>
 
-<pre><code>*/2 * * * * . ~/.bash_profile; cd /path/to/bot/;  ./bot.rb
-</code></pre>
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>*/2 * * * * . ~/.bash_profile; cd /path/to/bot/;  ./bot.rb
+</code></pre></div></div>
 
 <h2 id="looping">Looping</h2>
 <p>Run it as a background process.  Just put the guts of your bot in a loop like this:</p>
 
-<p>```rb
-loop do
-  search “twitter” do |tweet|
-    # here you could do something with a tweet
-    # if you want to retweet
-    retweet(tweet[:id])
-  end</p>
+<div class="language-rb highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="kp">loop</span> <span class="k">do</span>
+  <span class="n">search</span> <span class="s2">"twitter"</span> <span class="k">do</span> <span class="o">|</span><span class="n">tweet</span><span class="o">|</span>
+    <span class="c1"># here you could do something with a tweet</span>
+    <span class="c1"># if you want to retweet</span>
+    <span class="n">retweet</span><span class="p">(</span><span class="n">tweet</span><span class="p">[</span><span class="ss">:id</span><span class="p">])</span>
+  <span class="k">end</span>
 
-<p>replies do |tweet|
-    # do stuff
-  end</p>
+  <span class="n">replies</span> <span class="k">do</span> <span class="o">|</span><span class="n">tweet</span><span class="o">|</span>
+    <span class="c1"># do stuff</span>
+  <span class="k">end</span>
 
-<p># explicitly update our config
-  update_config</p>
+  <span class="c1"># explicitly update our config</span>
+  <span class="n">update_config</span>
 
-<p>sleep 60
-end
-```</p>
+  <span class="nb">sleep</span> <span class="mi">60</span>
+<span class="k">end</span>
+</code></pre></div></div>
 
-<p><strong>NOTE:</strong> You need to call <code>update_config</code> to update the last tweet your script
+<p><strong>NOTE:</strong> You need to call <code class="language-plaintext highlighter-rouge">update_config</code> to update the last tweet your script
 has processed – if you don’t have this call, you will get duplicate
 tweets.</p>
 
-<h2 id="streaming">Streaming</h2>
-
-<p>Chatterbot has rough support for the Streaming API. If your bot can
-use it, it’s a great option, because you get your data immediately.
-You can read more about setting up a bot to use <a href="streaming.html">streaming</a>.</p>
 
 
                     </div>

--- a/docs/_site/examples.html
+++ b/docs/_site/examples.html
@@ -341,7 +341,7 @@
 
 <p>Here’s a couple examples of working bots.</p>
 
-<h2 id="echoesbot">@echoes_bot</h2>
+<h2 id="echoes_bot">@echoes_bot</h2>
 
 <p>This is a working bot. It responds to any mentions with the incoming
 text:</p>
@@ -351,39 +351,38 @@ text:</p>
 
 <p>Here’s the code. This is right out of the git repo for chatterbot:</p>
 
-<p>```
-## This is a very simple working example of a bot you can build with
-## chatterbot. It looks for mentions of ‘@echoes_bot’ (the twitter
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>## This is a very simple working example of a bot you can build with
+## chatterbot. It looks for mentions of '@echoes_bot' (the twitter
 ## handle the bot uses), and sends replies with the name switched to
-## the handle of the sending user</p>
+## the handle of the sending user
 
-<p>#
+#
 # require the dsl lib to include all the methods you see below.
 #
-require ‘rubygems’
-require ‘chatterbot/dsl’</p>
+require 'rubygems'
+require 'chatterbot/dsl'
 
-<p>puts “Loading echoes_bot.rb”</p>
+puts "Loading echoes_bot.rb"
 
-<h1 id="section">#</h1>
-<p>## If I wanted to exclude some terms from triggering this bot, I would list them here.
-## For now, we’ll block URLs to keep this from being a source of spam
 ##
-exclude “http://”</p>
+## If I wanted to exclude some terms from triggering this bot, I would list them here.
+## For now, we'll block URLs to keep this from being a source of spam
+##
+exclude "http://"
 
-<p>blacklist “mean_user, private_user”</p>
+blacklist "mean_user, private_user"
 
-<p>puts “checking for replies to me”
+puts "checking for replies to me"
 replies do |tweet|
   # replace the incoming username with #USER#, which will be replaced
   # with the handle of the user who tweeted us by the
   # replace_variables helper
-  src = tweet.text.gsub(/@echoes_bot/, “#USER#”)  </p>
+  src = tweet.text.gsub(/@echoes_bot/, "#USER#")  
 
-<p># send it back!
+  # send it back!
   reply src, tweet
 end
-```</p>
+</code></pre></div></div>
 
 <h2 id="spacejamcheck">@SpaceJamCheck</h2>
 
@@ -391,105 +390,62 @@ end
 Jam to see if it is still online (it does this by using the spacejam
 gem), and tweets the results of that check.</p>
 
-<p>```
-#!/usr/bin/env ruby</p>
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>#!/usr/bin/env ruby
 
-<p>require ‘rubygems’
-require ‘bundler/setup’</p>
+require 'rubygems'
+require 'bundler/setup'
 
-<p>require ‘chatterbot/dsl’
-require ‘spacejam’</p>
+require 'chatterbot/dsl'
+require 'spacejam'
 
-<p>#
+#
 # this is the script for the twitter bot SpaceJamCheck
 # generated on 2013-11-04 16:24:46 -0500
-#</p>
+#
 
-<p>consumer_key ‘key’
-consumer_secret ‘secret’</p>
+consumer_key 'key'
+consumer_secret 'secret'
 
-<p>secret ‘secret’
-token ‘token’</p>
+secret 'secret'
+token 'token'
 
-<p>check_url = “http://www2.warnerbros.com/spacejam/movie/jam.htm”
-check_string = “<title>Space Jam</title>”</p>
 
-<p>uptime_messages = [
-                   “Hooray! Space Jam is still online!”,
-                   “It’s #{Time.now.year} and the Space Jam website is still online”,
-                   “In case you were worried, Space Jam is still online”,
-                   “Looks like the Space Jam website is still there”,
-                   “Yes”,
-                   “Yep”,
-                   “Still Kickin”,
-                   “The Space Jam website is still online”,
-                   “Still Online”
-                  ]</p>
+check_url = "http://www2.warnerbros.com/spacejam/movie/jam.htm"
+check_string = "&lt;title&gt;Space Jam&lt;/title&gt;"
 
-<p>downtime_messages = [
-                     “Hmm, looks like Space Jam isn’t online. Hopefully it’s a fluke ;(“
-                    ]</p>
+uptime_messages = [
+                   "Hooray! Space Jam is still online!",
+                   "It's #{Time.now.year} and the Space Jam website is still online",
+                   "In case you were worried, Space Jam is still online",
+                   "Looks like the Space Jam website is still there",
+                   "Yes",
+                   "Yep",
+                   "Still Kickin",
+                   "The Space Jam website is still online",
+                   "Still Online"
+                  ]
 
-<p>x = Spacejam::HTTPCheck.new(url:check_url, body:check_string)</p>
+downtime_messages = [
+                     "Hmm, looks like Space Jam isn't online. Hopefully it's a fluke ;("
+                    ]
 
-<h1 id="pick-a-random-tweet-according-to-the-website-status">pick a random tweet according to the website status</h1>
-<p>result = if x.online?
+
+x = Spacejam::HTTPCheck.new(url:check_url, body:check_string)
+
+# pick a random tweet according to the website status
+result = if x.online?
   uptime_messages
 else
   downtime_messages
-end.sample</p>
+end.sample
 
-<h1 id="add-a-timestamp-this-helps-to-prevent-duplicate-tweet-issues">add a timestamp. this helps to prevent duplicate tweet issues</h1>
-<p>result « ” (#{Time.now.utc})”</p>
+# add a timestamp. this helps to prevent duplicate tweet issues
+result &lt;&lt; " (#{Time.now.utc})"
 
-<h1 id="tweet-it-out">tweet it out!</h1>
-<p>tweet result
-```</p>
+# tweet it out!
+tweet result
+</code></pre></div></div>
 
-<h2 id="streaming-bot">Streaming Bot</h2>
-
-<p>```
-#!/usr/bin/env ruby</p>
-
-<h2 id="this-is-a-very-simple-working-example-of-a-bot-using-the-streaming">This is a very simple working example of a bot using the streaming</h2>
-<p>## API. It’s basically a copy of echoes_bot.rb, just using streaming.</p>
-
-<p>#
-# require the dsl lib to include all the methods you see below.
-#
-require ‘rubygems’
-require ‘chatterbot/dsl’</p>
-
-<p>consumer_secret ‘foo’
-secret ‘bar’
-token ‘biz’
-consumer_key ‘bam’</p>
-
-<p>puts “Loading echoes_bot.rb using the streaming API”</p>
-
-<p>exclude “http://”, “https://”</p>
-
-<p>blacklist “mean_user, private_user”</p>
-
-<p>streaming do
-  favorited do |user, tweet|
-    reply “@#{user.screen_name} thanks for the fave!”, tweet
-  end</p>
-
-<p>followed do |user|
-    tweet “@#{user.screen_name} just followed me!”
-    follow user
-  end</p>
-
-<p>replies do |tweet|
-    favorite tweet</p>
-
-<pre><code>puts "It's a tweet!"
-src = tweet.text.gsub(/@echoes_bot/, "#USER#")  
-reply src, tweet   end end
-</code></pre>
-
-<p>```</p>
 
 
                     </div>

--- a/docs/_site/features.html
+++ b/docs/_site/features.html
@@ -343,20 +343,20 @@
 
 <p><strong>search</strong> – You can use this to perform a search on Twitter:</p>
 
-<pre><code>search("'surely you must be joking'") do |tweet|
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>search("'surely you must be joking'") do |tweet|
   reply "#USER# I am serious, and don't call me Shirley!", tweet
 end
-</code></pre>
+</code></pre></div></div>
 
 <p>By default, Chatterbot keeps track of the last time you ran the bot,
 and it will only search for new tweets.</p>
 
 <p><strong>replies</strong> – Use this to check for replies and mentions:</p>
 
-<pre><code>replies do |tweet|
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>replies do |tweet|
   reply "#USER# Thanks for contacting me!", tweet
 end
-</code></pre>
+</code></pre></div></div>
 
 <p>Note that the string <strong>#USER#</strong> is automatically replaced with the
 username of the person who sent the original tweet. Also, Chatterbot
@@ -364,28 +364,27 @@ will only return tweets that were sent since the last run of the bot.</p>
 
 <p><strong>tweet</strong> – send a Tweet out for this bot:</p>
 
-<pre><code>tweet "I AM A BOT!!!"
-</code></pre>
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>tweet "I AM A BOT!!!"
+</code></pre></div></div>
 
 <p><strong>reply</strong> – reply to another tweet:</p>
 
-<pre><code>reply "THIS IS A REPLY TO #USER#!", original_tweet
-</code></pre>
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>reply "THIS IS A REPLY TO #USER#!", original_tweet
+</code></pre></div></div>
 
 <p><strong>retweet</strong> – Chatterbot can retweet tweets as well:</p>
 
-<p><code>rb
-  search "xyzzy" do |tweet|
-    retweet(tweet[:id])
-  end
-</code></p>
+<div class="language-rb highlighter-rouge"><div class="highlight"><pre class="highlight"><code>  <span class="n">search</span> <span class="s2">"xyzzy"</span> <span class="k">do</span> <span class="o">|</span><span class="n">tweet</span><span class="o">|</span>
+    <span class="n">retweet</span><span class="p">(</span><span class="n">tweet</span><span class="p">[</span><span class="ss">:id</span><span class="p">])</span>
+  <span class="k">end</span>
+</code></pre></div></div>
 
 <p><strong>blacklist</strong> – you can use this to specify a list of users you don’t
   want to interact with. If you put the following line at the top of
   your bot:</p>
 
-<pre><code>blacklist "user1, user2, user3"
-</code></pre>
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>blacklist "user1, user2, user3"
+</code></pre></div></div>
 
 <p>None of those users will trigger your bot if they come up in a
 search. However, if a user replies to one of your tweets or mentions
@@ -395,21 +394,21 @@ for replies.</p>
 <p><strong>exclude</strong> – similarly, you can specify a list of words/phrases
   which shouldn’t trigger your bot. If you use the following:</p>
 
-<pre><code>exclude "spam"
-</code></pre>
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>exclude "spam"
+</code></pre></div></div>
 
 <p>Any tweets or mentions with the word ‘spam’ in them will be ignored by
 the bot. If you wanted to ignore any tweets with links in them (a wise
 precaution if you want to avoid spreading spam), you could call:</p>
 
-<pre><code>exclude "http://"
-</code></pre>
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>exclude "http://"
+</code></pre></div></div>
 
 <p>The library actually comes with a pre-defined list of ‘bad words’
 which you can exclude by default by calling:</p>
 
-<pre><code>exclude bad_words
-</code></pre>
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>exclude bad_words
+</code></pre></div></div>
 
 <p>The word list is from Darius Kazemi’s
 <a href="https://github.com/dariusk/wordfilter">wordfilter</a>.</p>

--- a/docs/_site/index.html
+++ b/docs/_site/index.html
@@ -343,26 +343,25 @@ data.</p>
 
 <p>A bot using chatterbot can be as simple as this:</p>
 
-<p>```
-exclude “http://”
-blacklist “mean_user, private_user”</p>
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>exclude "http://"
+blacklist "mean_user, private_user"
 
-<p>puts “checking my timeline”
+puts "checking my timeline"
 home_timeline do |tweet|
     # i like to favorite things
     favorite tweet
-end</p>
+end
 
-<p>puts “checking for replies to my tweets and mentions of me”
+puts "checking for replies to my tweets and mentions of me"
 replies do |tweet|
   text = tweet.text
-  puts “message received: #{text}”
-  src = text.gsub(/@echoes_bot/, “#USER#”)  </p>
+  puts "message received: #{text}"
+  src = text.gsub(/@echoes_bot/, "#USER#")  
 
-<p># send it back!
+  # send it back!
   reply src, tweet
 end
-```</p>
+</code></pre></div></div>
 
 <p>Or you can write a bot using more traditional ruby classes.</p>
 
@@ -377,19 +376,18 @@ walk you through process of getting a bot authorized with Twitter.</p>
   <li>Simple blacklistling system to limit your annoyance of users</li>
   <li>Avoid your bot making a fool of itself by ignoring tweets with
 certain bad words</li>
-  <li>Basic Streaming API support</li>
   <li>Optionally log tweets to the database for metrics and tracking purposes</li>
 </ul>
 
 <p>Chatterbot uses the the Twitter gem
 (https://github.com/sferik/twitter) to handle the underlying API
 calls. Any calls to the search/reply methods will return
-<code>Twitter::Tweet</code> objects.</p>
+<code class="language-plaintext highlighter-rouge">Twitter::Tweet</code> objects.</p>
 
 <h2 id="copyrightlicense">Copyright/License</h2>
 
-<p>Copyright (c) 2014 Colin Mitchell. Chatterbot is distributed under the
-WTFPL license.</p>
+<p>Copyright (c) 2018 Colin Mitchell. Chatterbot is distributed under the
+MIT licence – Please see LICENSE.txt for further details.</p>
 
 <p>http://muffinlabs.com</p>
 

--- a/docs/_site/setup.html
+++ b/docs/_site/setup.html
@@ -381,13 +381,13 @@ your application. Later, we’ll remove the mobile number.</p>
 
 <p>Once you’ve registered your application, you have two options. You can
 create access tokens for your bot via Twitter, or you can run the
-<code>chatterbot-register</code> script. Running the script will take care of
+<code class="language-plaintext highlighter-rouge">chatterbot-register</code> script. Running the script will take care of
 creating a template file for your bot, but if you don’t want to do
 that, here are the steps for doing this manually:</p>
 
 <ul>
   <li>click the ‘Keys and Access Tokens’ link. You should see this: <img src="./images/04-access-token.png" /></li>
-  <li>click the ‘Create my access token’ link. </li>
+  <li>click the ‘Create my access token’ link.</li>
   <li>It might take a few minutes for Twitter to actually generate the
 token. You can refresh the page a couple times until they are there,
 then you can copy the keys into your application. There’s four keys
@@ -400,23 +400,14 @@ them:</li>
   following contents, pasting the credential values that you just
   generated:</p>
 
-<p><code>
-  ---
-  :consumer_secret: Consumer Secret (API Secret) GOES HERE
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>  ---
   :consumer_key: Consumer Key (API Key) GOES HERE
-  :token: Access Token GOES HERE
-  :secret: Access Token Secret GOES HERE
-</code></p>
+  :consumer_secret: Consumer Secret (API Secret) GOES HERE
+  :access_token: Access Token GOES HERE
+  :access_token_secret: Access Token Secret GOES HERE
+</code></pre></div></div>
 
-<p><strong>in the script</strong>. Add some lines to your bot script like this:
-<code>
-consumer_key 'Consumer Secret (API Secret)'
-consumer_secret 'Consumer Key (API Key)'
-secret 'Access Token Secret'
-token 'Access Token'
-</code></p>
-
-<p><strong>in a database</strong>. If you’ve setup chatterbot to use a database, you
+<p><strong>In a database</strong>. If you’ve setup chatterbot to use a database, you
   can store your configuration info in the <strong>config</strong> table.</p>
 
 <p><strong>NOTE</strong> At this point, you can remove the phone number from the bot

--- a/docs/_site/walkthrough.html
+++ b/docs/_site/walkthrough.html
@@ -346,12 +346,12 @@ Twitter.  That’s the easy part.</p>
 
 <h2 id="run-the-generator">Run the generator</h2>
 
-<p>Chatterbot comes with a script named <code>chatterbot-register</code> which will
+<p>Chatterbot comes with a script named <code class="language-plaintext highlighter-rouge">chatterbot-register</code> which will
 handle two tasks – it will authorize your bot with Twitter and it
 will generate a skeleton script, which you use to implement your
 actual bot.</p>
 
-<p>When you run <code>chatterbot-register</code> it will walk you through the
+<p>When you run <code class="language-plaintext highlighter-rouge">chatterbot-register</code> it will walk you through the
 authorization process. If you prefer, you can do this manually. If
 you’d like to learn more about it, you can read the
 <a href="setup.html">Authorizing your Bot</a> section.</p>
@@ -363,19 +363,19 @@ scripting commands which can handle almost everything you might need
 to do on Twitter.  You can get some ideas of things you can do on the
 <a href="examples.html">Examples</a> page.</p>
 
-<pre><code>require 'chatterbot/dsl'
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>require 'chatterbot/dsl'
 search("'surely you must be joking'") do |tweet|
   reply "@#{tweet_user(tweet)} I am serious, and don't call me Shirley!", tweet
 end
-</code></pre>
+</code></pre></div></div>
 
 <p>Or, you can create a bot object yourself, extend it if needed, and use it like so:</p>
 
-<pre><code>bot = Chatterbot::Bot.new
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>bot = Chatterbot::Bot.new
 bot.search("'surely you must be joking'") do |tweet|
  bot.reply "@#{tweet_user(tweet)} I am serious, and don't call me Shirley!", tweet
 end
-</code></pre>
+</code></pre></div></div>
 
 <p>That’s it!</p>
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -16,7 +16,7 @@ username/password.
 * Fill out the form. You need to put a name, description, and Website
   URL, although the URL doesn't need to exist. <img
   src="./images/01-create-application.png" />
-  
+
 
 * Save the form, and then click on the Permissions tab. You will need
   to specify what level of access is needed for your bot. <img
@@ -45,9 +45,9 @@ create access tokens for your bot via Twitter, or you can run the
 `chatterbot-register` script. Running the script will take care of
 creating a template file for your bot, but if you don't want to do
 that, here are the steps for doing this manually:
-  
-*  click the 'Keys and Access Tokens' link. You should see this: <img src="./images/04-access-token.png" />
-* click the 'Create my access token' link. 
+
+* click the 'Keys and Access Tokens' link. You should see this: <img src="./images/04-access-token.png" />
+* click the 'Create my access token' link.
 * It might take a few minutes for Twitter to actually generate the
   token. You can refresh the page a couple times until they are there,
   then you can copy the keys into your application. There's four keys
@@ -61,21 +61,13 @@ that, here are the steps for doing this manually:
 
 ```
   ---
-  :consumer_secret: Consumer Secret (API Secret) GOES HERE
   :consumer_key: Consumer Key (API Key) GOES HERE
-  :token: Access Token GOES HERE
-  :secret: Access Token Secret GOES HERE
+  :consumer_secret: Consumer Secret (API Secret) GOES HERE
+  :access_token: Access Token GOES HERE
+  :access_token_secret: Access Token Secret GOES HERE
 ```
 
-**in the script**. Add some lines to your bot script like this:
-```
-consumer_key 'Consumer Secret (API Secret)'
-consumer_secret 'Consumer Key (API Key)'
-secret 'Access Token Secret'
-token 'Access Token'
-```
-
-**in a database**. If you've setup chatterbot to use a database, you
+**In a database**. If you've setup chatterbot to use a database, you
   can store your configuration info in the **config** table.
 
 


### PR DESCRIPTION
Just a doc update. I must be using a newer version of jekyll because it also updated the html around code and pre tags.

But, the point of this PR is to update the token names. Also, I removed the option to insert the auth fields into the .rb file, since that doesn't seem to be allowed in the current chatterbot (I tried yesterday and got an error).
